### PR TITLE
Move to a direct deploy and use bootstrap CDN template as proof of concept

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,6 @@
 # dwgray.github.io
+
 A repo to back a very simple personal website
+
+I am using this to demostrate some basics of how websites work without a bunch of tooling.
+You can see the resulting site at [dwgray.github.io]

--- a/index.html
+++ b/index.html
@@ -1,0 +1,78 @@
+<!doctype html>
+<html lang="en">
+
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Bootstrap demo</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet"
+        integrity="sha384-T3c6CoIi6uLrA9TneNEoa7RxnatzjcDSCmG1MXxSR1GAsXEV/Dwwykc2MPK8M2HN" crossorigin="anonymous">
+    <link rel="stylesheet" href="styles.css">
+</head>
+
+<body>
+    <nav class="navbar navbar-expand-lg navbar-dark bg-dark">
+        <div class="container">
+            <a class="navbar-brand" href="#">Navbar</a>
+            <button class="navbar-toggler" type="button" data-bs-toggle="collapse"
+                data-bs-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false"
+                aria-label="Toggle navigation">
+                <span class="navbar-toggler-icon"></span>
+            </button>
+            <div class="collapse navbar-collapse" id="navbarSupportedContent">
+                <ul class="navbar-nav me-auto mb-2 mb-lg-0">
+                    <li class="nav-item">
+                        <a class="nav-link active" aria-current="page" href="#">Home</a>
+                    </li>
+                    <li class="nav-item">
+                        <a class="nav-link" href="#">Link</a>
+                    </li>
+                    <li class="nav-item dropdown">
+                        <a class="nav-link dropdown-toggle" href="#" id="navbarDropdown" role="button"
+                            data-bs-toggle="dropdown" aria-expanded="false">
+                            Dropdown
+                        </a>
+                        <ul class="dropdown-menu" aria-labelledby="navbarDropdown">
+                            <li><a class="dropdown-item" href="#">Action</a></li>
+                            <li><a class="dropdown-item" href="#">Another action</a></li>
+                            <li>
+                                <hr class="dropdown-divider">
+                            </li>
+                            <li><a class="dropdown-item" href="#">Something else here</a></li>
+                        </ul>
+                    </li>
+                    <li class="nav-item">
+                        <a class="nav-link disabled">Disabled</a>
+                    </li>
+                </ul>
+                <form class="d-flex" role="search">
+                    <input class="form-control me-2" type="search" placeholder="Search" aria-label="Search">
+                    <button class="btn btn-outline-success" type="submit">Search</button>
+                </form>
+            </div>
+        </div>
+    </nav>
+
+    <div class="container my-5">
+        <h1>Hello, world!</h1>
+        <div class="col-lg-8 px-0">
+            <p class="fs-5">You've successfully loaded up the Bootstrap starter example. It includes <a
+                    href="https://getbootstrap.com/">Bootstrap 5</a> via the <a
+                    href="https://www.jsdelivr.com/package/npm/bootstrap">jsDelivr CDN</a> and includes an additional
+                CSS and JS file for your own code.</p>
+            <p>Feel free to download or copy-and-paste any parts of this example.</p>
+
+            <hr class="col-1 my-4">
+
+            <a href="https://getbootstrap.com" class="btn btn-primary">Read the Bootstrap docs</a>
+            <a href="https://github.com/twbs/examples" class="btn btn-secondary">View on GitHub</a>
+        </div>
+    </div>
+
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"
+        integrity="sha384-C6RzsynM9kWDrMNeT87bh95OGNyZPhcTNXj1NW7RuBCsyN/o0jlpcV8Qyq46cDfL"
+        crossorigin="anonymous"></script>
+    <script src="main.js"></script>
+</body>
+
+</html>

--- a/main.js
+++ b/main.js
@@ -1,0 +1,5 @@
+//
+// Place any custom JS here
+//
+
+console.log("main.js loaded");

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,7 @@
+/*
+ * Custom CSS
+ */
+
+:root {
+  --bs-body-bg: var(--bs-gray-100);
+}


### PR DESCRIPTION
This PR is testing a couple of things out.

1. Adding the .nojekyll file to the root should directly deploy my files to the pages site
2. I pulled the [bootstrap](https://getbootstrap.com) [CDN template](https://github.com/twbs/examples/tree/main/starter/) to have something non-trivial to try - this pulls in a local stylesheet and .js file to show that relative paths are working.

In addition, I proved that this test site works as a local file system site (at least on windows) without even having to stand up a local server. I believe this is because of the fact that all of my local references are relative paths.